### PR TITLE
Disable in non DIY mode on gl170 to avoid crashes

### DIFF
--- a/control/control
+++ b/control/control
@@ -1,5 +1,5 @@
 Package: image-changer
-Version: 1.0.2
+Version: 1.0.3
 Maintainer: D3VL LTD <jack@d3vl.com>
 Description: Changes the default DJI Splash Screen and Screensavers to WTFOS ones
 Architecture: pigeon-glasses

--- a/data/opt/bin/image-changer.sh
+++ b/data/opt/bin/image-changer.sh
@@ -1,5 +1,11 @@
 #!/system/bin/sh
 
+# non DIY mode on gl170 can cause (rare) crashes at startup
+if [ "$(getprop ro.product.device)" = "pigeon_wm170_gls" ] && [ "$(unrd product_type)" != "wm150_gls" ]; then
+    echo "[image-changer] gl170 and not DIY mode, bailing";
+    exit 0
+fi
+
 echo "[image-changer] start";
 
 function checkImageSize {


### PR DESCRIPTION
Was able to reproduce crashes every n-th power up (around 5?) in O3 / Avata / FPV Drone mode. adb stops working, nothing in logs.

Disabled in non DIY mode on gl170 to avoid crashes.